### PR TITLE
Fix single hex movement

### DIFF
--- a/gameCode/bugMoveLogic/bugLogic/beetle.logic.js
+++ b/gameCode/bugMoveLogic/bugLogic/beetle.logic.js
@@ -1,7 +1,7 @@
 import { checkSingleHexMove } from "../logic.util.js";
 
-export function checkBeetleMove(move) {
-    return checkSingleHexMove(move)
+export function checkBeetleMove(move, board) {
+    return checkSingleHexMove(move, board)
 }
 
 export default checkBeetleMove;

--- a/gameCode/bugMoveLogic/bugLogic/beetle.logic.js
+++ b/gameCode/bugMoveLogic/bugLogic/beetle.logic.js
@@ -1,4 +1,4 @@
-import { checkSingleHexMove } from "../logic.util.js";
+import { checkSingleHexMove } from "../singleHexMove.util.js";
 
 export function checkBeetleMove(move, board) {
     return checkSingleHexMove(move, board)

--- a/gameCode/bugMoveLogic/bugLogic/queenBee.logic.js
+++ b/gameCode/bugMoveLogic/bugLogic/queenBee.logic.js
@@ -1,7 +1,7 @@
 import { checkSingleHexMove } from "../logic.util.js";
 
-export function checkQueenBeeMove(move) {
-    return checkSingleHexMove(move)
+export function checkQueenBeeMove(move, board) {
+    return checkSingleHexMove(move, board)
 }
 
 export default checkQueenBeeMove;

--- a/gameCode/bugMoveLogic/bugLogic/queenBee.logic.js
+++ b/gameCode/bugMoveLogic/bugLogic/queenBee.logic.js
@@ -1,4 +1,4 @@
-import { checkSingleHexMove } from "../logic.util.js";
+import { checkSingleHexMove } from "../singleHexMove.util.js";
 
 export function checkQueenBeeMove(move, board) {
     return checkSingleHexMove(move, board)

--- a/gameCode/bugMoveLogic/bugLogic/spider.logic.js
+++ b/gameCode/bugMoveLogic/bugLogic/spider.logic.js
@@ -30,7 +30,7 @@ function checkSpiderMove(move, board) {
         }
         moveCoords = proposedMoveCoords
     }
-    console.log(moveCoords)
+    //console.log(moveCoords)
     if(doesArrayContainObject(moveCoords, move.destCoord)) bIsMoveGood = true
     return bIsMoveGood
 }

--- a/gameCode/bugMoveLogic/checkMove.js
+++ b/gameCode/bugMoveLogic/checkMove.js
@@ -10,9 +10,9 @@ function isMoveLegal(move,board) {
     const bugType = move.moveBug.type
     let bIsMoveLegal = false
     if(bugType == "queenBee") {
-        bIsMoveLegal = checkQueenBeeMove(move)
+        bIsMoveLegal = checkQueenBeeMove(move, board)
     } else if (bugType == "beetle") {
-        bIsMoveLegal = checkBeetleMove(move)
+        bIsMoveLegal = checkBeetleMove(move, board)
     } else if (bugType == "hopper") {
         bIsMoveLegal = checkHopperMove(move,board)
     } else if (bugType == "spider") {

--- a/gameCode/bugMoveLogic/logic.util.js
+++ b/gameCode/bugMoveLogic/logic.util.js
@@ -1,4 +1,5 @@
 import { translateRefCoordToArrayCoord } from "../utils/coordinateTranslate.util.js";
+import CellState from "../gameObjects/cellState.js";
 
 export function checkCrescentBreak(move, board) {
     let bIsMoveGood = true
@@ -13,16 +14,49 @@ export function checkCrescentBreak(move, board) {
     return bIsMoveGood
 }
 
-export function checkSingleHexMove(move) { //need to redo this potentially?
+export function checkSingleHexMove(move, board) {
+    let isMoveOneHex = false
     const [x0,y0] = move.startCoord
     const [x1,y1] = move.destCoord
     const x = x1 - x0
     const y = y1 - y0
-    const distance =  Math.sqrt(x * x + y * y)
-    let isMoveOneHex = false
-    if(distance == 2) isMoveOneHex = true
-    else if(distance == Math.sqrt(5)) isMoveOneHex = true
-    else isMoveOneHex = false
+    if( x == 0 && Math.abs(y) == 2) {
+        if(move.moveBug.type == "beetle") isMoveOneHex = true
+        else { //rolling case
+            if( y > 0) { // moving right
+                const topRightCoord = [x0-2,y0+1]
+                const bottomRightCoord = [x0+2,y0+1]
+                if(x0-2>0) {
+                    let tempCell = new CellState(topRightCoord)
+                    let topRightCell = tempCell
+                    topRightCell = board.getCellFromRefCoord(topRightCoord)
+                    if(!topRightCell.isEmpty()) isMoveOneHex = true
+                } else {
+                    let tempCell = new CellState(topRightCoord)
+                    let bottomRightCell = tempCell
+                    bottomRightCell = board.getCellFromRefCoord(bottomRightCoord)
+                    if(!bottomRightCell.isEmpty()) isMoveOneHex = true
+                }
+            } else { //left
+                const topLeftCoord = [x0-2,y0-1]
+                const bottomLeftCoord = [x0+2,y0-1]
+                if(y0-1 > 0) {
+                    if(x0-2>0) {
+                        let tempCell = new CellState(topLeftCoord)
+                        let topLeftCell = tempCell
+                        topLeftCell = board.getCellFromRefCoord(topLeftCoord)
+                        if(!topLeftCell.isEmpty()) isMoveOneHex = true
+                    } else {
+                        let tempCell = new CellState(topLeftCoord)
+                        let bottomLeftCell = tempCell
+                        bottomLeftCell = board.getCellFromRefCoord(bottomLeftCoord)
+                        if(!bottomLeftCell.isEmpty()) isMoveOneHex = true
+                    }
+                }
+            }
+        }
+    }
+    else if (Math.abs(x) == 2 && Math.abs(y) == 1) isMoveOneHex = true
     return isMoveOneHex
 }
 
@@ -50,7 +84,7 @@ export function createBoardWithoutMoveBug(move,board) {
 export function checkMoveLite(move, board, ignore) {  
     let bIsMoveGood = false
     if(isHexOpen(move, board)) {
-        if(checkSingleHexMove(move)) {
+        if(checkSingleHexMove(move, board)) {
             if(isDestHexAdjacent(move,board, ignore)) {
                 if(isEndStateLegal(move, board)) {
                     bIsMoveGood = true

--- a/gameCode/bugMoveLogic/logic.util.js
+++ b/gameCode/bugMoveLogic/logic.util.js
@@ -1,5 +1,5 @@
 import { translateRefCoordToArrayCoord } from "../utils/coordinateTranslate.util.js";
-import CellState from "../gameObjects/cellState.js";
+import { checkSingleHexMove } from "./singleHexMove.util.js"
 
 export function checkCrescentBreak(move, board) {
     let bIsMoveGood = true
@@ -12,52 +12,6 @@ export function checkCrescentBreak(move, board) {
         }
     }
     return bIsMoveGood
-}
-
-export function checkSingleHexMove(move, board) {
-    let isMoveOneHex = false
-    const [x0,y0] = move.startCoord
-    const [x1,y1] = move.destCoord
-    const x = x1 - x0
-    const y = y1 - y0
-    if( x == 0 && Math.abs(y) == 2) {
-        if(move.moveBug.type == "beetle") isMoveOneHex = true
-        else { //rolling case
-            if( y > 0) { // moving right
-                const topRightCoord = [x0-2,y0+1]
-                const bottomRightCoord = [x0+2,y0+1]
-                if(x0-2>0) {
-                    let tempCell = new CellState(topRightCoord)
-                    let topRightCell = tempCell
-                    topRightCell = board.getCellFromRefCoord(topRightCoord)
-                    if(!topRightCell.isEmpty()) isMoveOneHex = true
-                } else {
-                    let tempCell = new CellState(topRightCoord)
-                    let bottomRightCell = tempCell
-                    bottomRightCell = board.getCellFromRefCoord(bottomRightCoord)
-                    if(!bottomRightCell.isEmpty()) isMoveOneHex = true
-                }
-            } else { //left
-                const topLeftCoord = [x0-2,y0-1]
-                const bottomLeftCoord = [x0+2,y0-1]
-                if(y0-1 > 0) {
-                    if(x0-2>0) {
-                        let tempCell = new CellState(topLeftCoord)
-                        let topLeftCell = tempCell
-                        topLeftCell = board.getCellFromRefCoord(topLeftCoord)
-                        if(!topLeftCell.isEmpty()) isMoveOneHex = true
-                    } else {
-                        let tempCell = new CellState(topLeftCoord)
-                        let bottomLeftCell = tempCell
-                        bottomLeftCell = board.getCellFromRefCoord(bottomLeftCoord)
-                        if(!bottomLeftCell.isEmpty()) isMoveOneHex = true
-                    }
-                }
-            }
-        }
-    }
-    else if (Math.abs(x) == 2 && Math.abs(y) == 1) isMoveOneHex = true
-    return isMoveOneHex
 }
 
 export function isHexOpen(move,board) { //is the space where the player intends to move occupied already
@@ -81,6 +35,16 @@ export function createBoardWithoutMoveBug(move,board) {
     return boardWithoutMoveBug
 }
 
+
+export function isEndStateLegal (move, board) { //need to check anything besides crescent break?
+    let isMoveGood = true
+    const bugType = move.moveBug.type
+
+    if(bugType != "beetle" && bugType != "hopper")
+        isMoveGood = checkCrescentBreak(move,board)
+    return isMoveGood
+}
+
 export function checkMoveLite(move, board, ignore) {  
     let bIsMoveGood = false
     if(isHexOpen(move, board)) {
@@ -95,13 +59,4 @@ export function checkMoveLite(move, board, ignore) {
     return bIsMoveGood
 }
 
-export function isEndStateLegal (move, board) { //need to check anything besides crescent break?
-    let isMoveGood = true
-    const bugType = move.moveBug.type
-
-    if(bugType != "beetle" && bugType != "hopper")
-        isMoveGood = checkCrescentBreak(move,board)
-    return isMoveGood
-}
-
-export default checkSingleHexMove
+export default checkMoveLite

--- a/gameCode/bugMoveLogic/singleHexMove.util.js
+++ b/gameCode/bugMoveLogic/singleHexMove.util.js
@@ -1,0 +1,39 @@
+export function checkSingleHexMove(move, board) {
+    let isMoveOneHex = false
+    const [x0,y0] = move.startCoord
+    const [x1,y1] = move.destCoord
+    const x = x1 - x0
+    const y = y1 - y0
+    if( x == 0 && Math.abs(y) == 2) {
+        if(move.moveBug.type == "beetle") isMoveOneHex = true
+        else { //rolling case
+            if( y > 0) { // moving right
+                const topRightCoord = [x0-2,y0+1]
+                const bottomRightCoord = [x0+2,y0+1]
+                if(x0-2>0) {
+                    const topRightCell = board.getCellFromRefCoord(topRightCoord)
+                    if(!topRightCell.isEmpty()) isMoveOneHex = true
+                } else {
+                    const bottomRightCell = board.getCellFromRefCoord(bottomRightCoord)
+                    if(!bottomRightCell.isEmpty()) isMoveOneHex = true
+                }
+            } else { //left
+                const topLeftCoord = [x0-2,y0-1]
+                const bottomLeftCoord = [x0+2,y0-1]
+                if(y0-1 > 0) {
+                    if(x0-2>0) {
+                        const topLeftCell = board.getCellFromRefCoord(topLeftCoord)
+                        if(!topLeftCell.isEmpty()) isMoveOneHex = true
+                    } else {
+                        const bottomLeftCell = board.getCellFromRefCoord(bottomLeftCoord)
+                        if(!bottomLeftCell.isEmpty()) isMoveOneHex = true
+                    }
+                }
+            }
+        }
+    }
+    else if (Math.abs(x) == 2 && Math.abs(y) == 1) isMoveOneHex = true
+    return isMoveOneHex
+}
+
+export default checkSingleHexMove

--- a/gameCode/bugMoveLogic/singleHexMove.util.js
+++ b/gameCode/bugMoveLogic/singleHexMove.util.js
@@ -13,7 +13,8 @@ export function checkSingleHexMove(move, board) {
                 if(x0-2>0) {
                     const topRightCell = board.getCellFromRefCoord(topRightCoord)
                     if(!topRightCell.isEmpty()) isMoveOneHex = true
-                } else {
+                }
+                if (!isMoveOneHex) {
                     const bottomRightCell = board.getCellFromRefCoord(bottomRightCoord)
                     if(!bottomRightCell.isEmpty()) isMoveOneHex = true
                 }
@@ -24,7 +25,8 @@ export function checkSingleHexMove(move, board) {
                     if(x0-2>0) {
                         const topLeftCell = board.getCellFromRefCoord(topLeftCoord)
                         if(!topLeftCell.isEmpty()) isMoveOneHex = true
-                    } else {
+                    } 
+                    if (!isMoveOneHex) {
                         const bottomLeftCell = board.getCellFromRefCoord(bottomLeftCoord)
                         if(!bottomLeftCell.isEmpty()) isMoveOneHex = true
                     }
@@ -32,7 +34,7 @@ export function checkSingleHexMove(move, board) {
             }
         }
     }
-    else if (Math.abs(x) == 2 && Math.abs(y) == 1) isMoveOneHex = true
+    else if (Math.abs(x) == 2 && Math.abs(y) == 1) isMoveOneHex = true //may need more conditions
     return isMoveOneHex
 }
 

--- a/gameCode/game/gameLogic.js
+++ b/gameCode/game/gameLogic.js
@@ -1,6 +1,4 @@
-import Board from "../gameObjects/board.js"
 import Bug from "../gameObjects/bugs.js"
-import CellState from "../gameObjects/cellState.js"
 
 export function addBugToGame(placement, board) {
     const player = placement.player

--- a/test/basicMovement/spider.test.js
+++ b/test/basicMovement/spider.test.js
@@ -9,7 +9,7 @@ describe("Basic Movement Logic Tests: Spider", function () {
     let testBoard;
     let moveSpider, staticSpider1;
     beforeEach(function() {
-        testBoard = new Board(7)
+        testBoard = new Board(8)
         moveSpider = new spider("white",[4,5])
         staticSpider1 = new spider("black",[6,6])
 

--- a/test/basicMovement/spider.test.js
+++ b/test/basicMovement/spider.test.js
@@ -28,7 +28,7 @@ describe("Basic Movement Logic Tests: Spider", function () {
         const staticSpider2 = new spider("black",[8,5])
         testBoard.addToBoard(staticSpider2)
 
-        const move = new Move(moveSpider,[10,4])
+        const move = new Move(moveSpider,[8,7]) //10,4
         const [check,message] = checkMove(move, testBoard)
         expect(check).to.be.true;
         expect(message).to.eq("Success")
@@ -61,12 +61,16 @@ describe("Basic Movement Logic Tests: Spider", function () {
 
         const move1 = new Move(moveSpider,[10,2])
         const move2 = new Move(moveSpider,[10,4])
-        const move3 = new Move(moveSpider,[4,1]) //this is the hard case
+        const move3 = new Move(moveSpider,[4,1])
         const move4 = new Move(moveSpider,[8,9])
 
-        const [check,message] = checkMove(move4, testBoard)
-        expect(check).to.be.true;
-        expect(message).to.eq("Success")
-
+        const [check1,message1] = checkMove(move1, testBoard)
+        const [check2,message2] = checkMove(move2, testBoard)
+        const [check3,message3] = checkMove(move3, testBoard)
+        const [check4,message4] = checkMove(move4, testBoard)
+        expect(check1).to.be.true;
+        expect(check2).to.be.true;
+        expect(check3).to.be.true;
+        expect(check4).to.be.true;
     })
 })


### PR DESCRIPTION
Now using the nature of the reference array instead of distances to decide if a single hex move is allowed. Needed to account for "rolling" case.